### PR TITLE
列分隔符和行分隔符改为使用String类型的对称字符串

### DIFF
--- a/src/main/java/com/starrocks/plugin/audit/AuditLoaderPlugin.java
+++ b/src/main/java/com/starrocks/plugin/audit/AuditLoaderPlugin.java
@@ -61,11 +61,11 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
     /**
      * 列分隔符
      */
-    private static final char COLUMN_SEPARATOR = 0x01;
+    private static final String COLUMN_SEPARATOR = "~&^*^&~";
     /**
      * 行分隔符
      */
-    private static final char ROW_DELIMITER = 0x02;
+    private static final String ROW_DELIMITER = "!$_$!";
 
     @Override
     public void init(PluginInfo info, PluginContext ctx) throws PluginException {


### PR DESCRIPTION
SR 3.2.12 版本升级了 netty 版本到netty-4.1.114.Final. 其中使用了 `0X01`  .导致了原有的插件程序报错.